### PR TITLE
Moved the dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.1.0",
     "react-native": "^0.27.2"
   },


### PR DESCRIPTION
I kept getting the `Duplicate module name: react-native` in react-native packager since react-native is added as a dependency rather peerDependency in this project. Moving the dependencies to peerDependencies work.